### PR TITLE
Add support for CORS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,6 @@ resource "aws_cloudfront_distribution" "site" {
   origin {
     domain_name = "${module.static_site.site_bucket}.s3.amazonaws.com"
     origin_id   = "SwaggerSiteOriginEastId"
-
-    custom_origin_config {
-      http_port              = 80
-      https_port             = 443
-      origin_protocol_policy = "http-only"
-      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
-    }
   }
 ...
 
@@ -37,9 +30,15 @@ resource "aws_cloudfront_distribution" "site" {
 # Variables
 `bucket_name` - Name of bucket where the site will be hosted.
 `logs_bucket_name` - Name of the access logs bucket.
+`region`  - Name of the region where buckets should be created (default: `us-east-1`)
+`cors_allowed_headers` - Allowed CORS headers (default: `["Authorization"]`)
+`cors_allowed_methods` - Allowed CORS methods (default: `["GET"]`)
+`cors_allowed_origins` - Allowed CORS origins (default: `["*"]`)
+`cors_expose_headers` - Headers to expose in the response (default: `[]`)
+`cors_max_age_seconds` - Maximum seconds a browser can cache a response (default: `3000`)
+
 `project` - Name of the project that this site is for (default: `Unknown`)
 `environment` - Name of the environment this site is targeting (default: `Unknown`)
-`region`  - Name of the region where buckets should be created (default: `us-east-1`)
 
 # Outputs
 `site_bucket` - Name of the site bucket

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,14 @@ resource "aws_s3_bucket" "site_bucket" {
   policy = "${data.aws_iam_policy_document.read_only_bucket_policy.json}"
   region = "${var.region}"
 
+  cors_rule {
+    allowed_headers = "${var.cors_allowed_headers}"
+    allowed_methods = "${var.cors_allowed_methods}"
+    allowed_origins = "${var.cors_allowed_origins}"
+    expose_headers  = "${var.cors_expose_headers}"
+    max_age_seconds = "${var.cors_max_age_seconds}"
+  }
+
   tags {
     Project     = "${var.project}"
     Environment = "${var.environment}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,26 @@
 variable "bucket_name" {}
 variable "logs_bucket_name" {}
 
+variable "cors_allowed_headers" {
+  default = ["Authorization"]
+}
+
+variable "cors_allowed_methods" {
+  default = ["GET"]
+}
+
+variable "cors_allowed_origins" {
+  default = ["*"]
+}
+
+variable "cors_expose_headers" {
+  default = []
+}
+
+variable "cors_max_age_seconds" {
+  default = "3000"
+}
+
 variable "region" {
   default = "us-east-1"
 }


### PR DESCRIPTION
Allows users to setup a CORS configuration on the site bucket.

# Testing
azavea/raster-foundry-deployment#41