### PR TITLE
Update IAM policy document parameters to align with new provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "read_only_bucket_policy" {
     effect = "Allow"
 
     principals {
-      type        = "AWS"
+      type        = "*"
       identifiers = ["*"]
     }
 


### PR DESCRIPTION
Change IAM principal type to `"*"` to comply with the new Terraform provider parameters. When the principal `type` is `AWS`, read access is restricted to authenticated IAM users. When the `type` is `"*"`, Read access is anonymous (which is what we want for this role).

Testing

See azavea/raster-foundry-deployment#135