### PR TITLE
Upgrade module to support Terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Terraform module to create an origin S3 bucket (for use with CloudFront) with 
 # Usage
 ```hcl
 module "static_site" {
-  source                      = "github.com/azavea/terraform-aws-s3-origin?ref=0.1.0"
+  source                      = "github.com/azavea/terraform-aws-s3-origin"
   bucket_name                 = "mysite-bucket"
   logs_bucket_name             = "mysite-logs-bucket"
   project                     = "Unknown"
@@ -42,6 +42,7 @@ resource "aws_cloudfront_distribution" "site" {
 - `cors_max_age_seconds` - Maximum seconds a browser can cache a response (default: `3000`)
 - `project` - Name of the project that this site is for (default: `Unknown`)
 - `environment` - Name of the environment this site is targeting (default: `Unknown`)
+- `tags` - A mapping of keys and values to apply as tags to all resources that support them.
 
 # Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -23,31 +23,37 @@ data "aws_iam_policy_document" "read_only_bucket_policy" {
 }
 
 resource "aws_s3_bucket" "site_bucket" {
-  bucket = "${var.bucket_name}"
-  policy = "${data.aws_iam_policy_document.read_only_bucket_policy.json}"
-  region = "${var.region}"
+  bucket = var.bucket_name
+  policy = data.aws_iam_policy_document.read_only_bucket_policy.json
+  region = var.region
 
   cors_rule {
-    allowed_headers = "${var.cors_allowed_headers}"
-    allowed_methods = "${var.cors_allowed_methods}"
-    allowed_origins = "${var.cors_allowed_origins}"
-    expose_headers  = "${var.cors_expose_headers}"
-    max_age_seconds = "${var.cors_max_age_seconds}"
+    allowed_headers = var.cors_allowed_headers
+    allowed_methods = var.cors_allowed_methods
+    allowed_origins = var.cors_allowed_origins
+    expose_headers  = var.cors_expose_headers
+    max_age_seconds = var.cors_max_age_seconds
   }
 
-  tags {
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
-  }
+  tags = merge(
+    {
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags,
+  )
 }
 
 resource "aws_s3_bucket" "access_logs_bucket" {
-  bucket = "${var.logs_bucket_name}"
+  bucket = var.logs_bucket_name
   acl    = "log-delivery-write"
-  region = "${var.region}"
+  region = var.region
 
-  tags {
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
-  }
+  tags = merge(
+    {
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags,
+  )
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 output "site_bucket" {
-  value = "${aws_s3_bucket.site_bucket.id}"
+  value = aws_s3_bucket.site_bucket.id
 }
 
 output "logs_bucket" {
-  value = "${aws_s3_bucket.access_logs_bucket.id}"
+  value = aws_s3_bucket.access_logs_bucket.id
 }

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -3,20 +3,20 @@
 set -e
 
 if [[ -n "${CI_DEBUG}" ]]; then
-    set -x
+	set -x
 fi
 
 function usage() {
-    echo -n \
-    "Usage: $(basename "$0")
+	echo -n \
+		"Usage: $(basename "$0")
 Ensure the Terraform source code is properly formatted.
 "
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-    if [ "${1:-}" = "--help" ]; then
-        usage
-    else
-        terraform fmt -check
-    fi
+	if [ "${1:-}" = "--help" ]; then
+		usage
+	else
+		terraform fmt -check
+	fi
 fi

--- a/variables.tf
+++ b/variables.tf
@@ -1,34 +1,52 @@
-variable "bucket_name" {}
-variable "logs_bucket_name" {}
+variable "bucket_name" {
+  type = string
+}
+
+variable "logs_bucket_name" {
+  type = string
+}
 
 variable "cors_allowed_headers" {
   default = ["Authorization"]
+  type    = list(string)
 }
 
 variable "cors_allowed_methods" {
   default = ["GET"]
+  type    = list(string)
 }
 
 variable "cors_allowed_origins" {
   default = ["*"]
+  type    = list(string)
 }
 
 variable "cors_expose_headers" {
   default = []
+  type    = list(string)
 }
 
 variable "cors_max_age_seconds" {
-  default = "3000"
+  default = 3000
+  type    = number
 }
 
 variable "region" {
   default = "us-east-1"
+  type    = string
 }
 
 variable "project" {
   default = "Unknown"
+  type    = string
 }
 
 variable "environment" {
   default = "Unknown"
+  type    = string
+}
+
+variable "tags" {
+  default = {}
+  type    = map(string)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    aws = ">= 2.33.0"
+  }
+}


### PR DESCRIPTION
Following the instructions outlined in the [Terraform documentation](https://www.terraform.io/upgrade-guides/0-12.html), update the module's configuration to support Terraform 0.12. Despite containing minor changes, this is expected to cause a major version bump, because the changes are not backwards compatible.

---

**Testing**

Please use https://github.com/azavea/azavea-data-hub/pull/60 to test this PR.