### PR TITLE
Remove read-only region attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Remove read-only `region` attribute.
 - Require AWS provider >= 3.0.0.
+- Add `site_bucket_regional_domain_name` output.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0
+
+- Remove read-only `region` attribute.
+- Require AWS provider >= 3.0.0.
+
 ## 1.0.0
 
 - Add support for Terraform 0.12.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Azavea, Inc.
+   Copyright 2020 Azavea, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -45,5 +45,6 @@ resource "aws_cloudfront_distribution" "site" {
 # Outputs
 
 - `site_bucket` - Name of the site bucket
+- `site_bucket_regional_domain_name` - The region-specific domain name of the site bucket
 - `logs_bucket` - Name of the logs bucket
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ module "static_site" {
   logs_bucket_name             = "mysite-logs-bucket"
   project                     = "Unknown"
   environment                 = "Unknown"
-  region                      = "us-east-1"
 }
 
 
@@ -34,7 +33,6 @@ resource "aws_cloudfront_distribution" "site" {
 
 - `bucket_name` - Name of bucket where the site will be hosted.
 - `logs_bucket_name` - Name of the access logs bucket.
-- `region`  - Name of the region where buckets should be created (default: `us-east-1`)
 - `cors_allowed_headers` - Allowed CORS headers (default: `["Authorization"]`)
 - `cors_allowed_methods` - Allowed CORS methods (default: `["GET"]`)
 - `cors_allowed_origins` - Allowed CORS origins (default: `["*"]`)

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,6 @@ data "aws_iam_policy_document" "read_only_bucket_policy" {
 resource "aws_s3_bucket" "site_bucket" {
   bucket = var.bucket_name
   policy = data.aws_iam_policy_document.read_only_bucket_policy.json
-  region = var.region
 
   cors_rule {
     allowed_headers = var.cors_allowed_headers
@@ -47,7 +46,6 @@ resource "aws_s3_bucket" "site_bucket" {
 resource "aws_s3_bucket" "access_logs_bucket" {
   bucket = var.logs_bucket_name
   acl    = "log-delivery-write"
-  region = var.region
 
   tags = merge(
     {

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,10 @@ output "site_bucket" {
   value = aws_s3_bucket.site_bucket.id
 }
 
+output "site_bucket_regional_domain_name" {
+  value = aws_s3_bucket.site_bucket.bucket_regional_domain_name
+}
+
 output "logs_bucket" {
   value = aws_s3_bucket.access_logs_bucket.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,11 +31,6 @@ variable "cors_max_age_seconds" {
   type    = number
 }
 
-variable "region" {
-  default = "us-east-1"
-  type    = string
-}
-
 variable "project" {
   default = "Unknown"
   type    = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = ">= 2.33.0"
+    aws = ">= 3.0.0"
   }
 }


### PR DESCRIPTION
The `region` attribute has been made read-only as of [v3.0.0 of the AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#region-attribute-is-now-read-only) and has been removed as an argument. This also bumps the minimum required AWS provider version to 3.0.0.

This change will require a major version bump for this module to 2.0.0.

### Testing Instructions

* Verify in a project that uses this revision that the Terraform module loads and all resources are created successfully without specifying the `region` argument.